### PR TITLE
Performance improvements

### DIFF
--- a/src/Pointer/NonExistentValue.php
+++ b/src/Pointer/NonExistentValue.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace League\JsonReference\Pointer;
+
+/**
+ * Represents a value referenced by a pointer that does not exist in the JSON data.
+ */
+final class NonExistentValue
+{
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @param string $value The referenced value.
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/ScopeResolver/JsonSchemaScopeResolver.php
+++ b/src/ScopeResolver/JsonSchemaScopeResolver.php
@@ -3,8 +3,6 @@
 namespace League\JsonReference\ScopeResolver;
 
 use League\JsonReference\ScopeResolverInterface;
-use function League\JsonReference\pointer;
-use function League\JsonReference\pointer_push;
 use function League\JsonReference\resolve_uri;
 
 final class JsonSchemaScopeResolver implements ScopeResolverInterface
@@ -30,18 +28,14 @@ final class JsonSchemaScopeResolver implements ScopeResolverInterface
      */
     public function resolve($schema, $currentPointer, $currentScope)
     {
-        $pointer     = pointer($schema);
-        $currentPath = '';
-
+        $current = $schema;
         foreach (explode('/', $currentPointer) as $segment) {
-            if (!empty($segment)) {
-                $currentPath = pointer_push($currentPath, $segment);
+            if (isset($current->$segment)) {
+                $current = $current->$segment;
             }
-            if ($pointer->has($currentPath . '/' . $this->keyword)) {
-                $id = $pointer->get($currentPath . '/' . $this->keyword);
-                if (is_string($id)) {
-                    $currentScope = resolve_uri($id, $currentScope);
-                }
+            $id = isset($current->{$this->keyword}) ? $current->{$this->keyword} : null;
+            if (is_string($id)) {
+                $currentScope = resolve_uri($id, $currentScope);
             }
         }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -22,8 +22,7 @@ function pointer(&$json)
  */
 function escape_pointer($pointer)
 {
-    $pointer = str_replace('~', '~0', $pointer);
-    return str_replace('/', '~1', $pointer);
+    return str_replace(['~', '/'], ['~0', '~1'], $pointer);
 }
 
 
@@ -38,7 +37,7 @@ function escape_pointer($pointer)
  */
 function pointer_push($pointer, ...$segments)
 {
-    $segments =  array_map('League\JsonReference\escape_pointer', $segments);
+    $segments = str_replace(['~', '/'], ['~0', '~1'], $segments);
     return ($pointer !== '/' ? $pointer : '') . '/' . implode('/', $segments);
 }
 
@@ -168,7 +167,7 @@ function schema_extract($schema, callable $callback, $pointer = '')
 {
     $matches = [];
 
-    if ((!is_array($schema) && !is_object($schema)) || $schema instanceof Reference) {
+    if ($schema instanceof Reference || (!is_array($schema) && !is_object($schema))) {
         return $matches;
     }
 

--- a/tests/benchmarks/DereferenceBenchmark.php
+++ b/tests/benchmarks/DereferenceBenchmark.php
@@ -31,24 +31,25 @@ abstract class DereferenceBenchmark extends Benchmark
         $this->arrayCache  = new SimpleCacheBridge(new ArrayCachePool());
 
         $this->redisCache = new SimpleCacheBridge(new PredisCachePool($predis = new Client()));
+
         $predis->connect();
     }
 
     public function benchStandard()
     {
         $schema = $this->schema;
-        (new Dereferencer())->dereference($schema);
+        Dereferencer::draft4()->dereference($schema);
     }
 
     public function benchArrayCache()
     {
         $schema = $this->schema;
-        (new CachedDereferencer(new Dereferencer(), $this->arrayCache))->dereference($schema);
+        (new CachedDereferencer(Dereferencer::draft4(), $this->arrayCache))->dereference($schema);
     }
 
     public function benchRedisCache()
     {
         $schema = $this->schema;
-        (new CachedDereferencer(new Dereferencer(), $this->redisCache))->dereference($schema);
+        (new CachedDereferencer(Dereferencer::draft4(), $this->redisCache))->dereference($schema);
     }
 }


### PR DESCRIPTION
I ran some tests with blackfire because dereferencing the swagger schema seemed slow.  Apparently the JSON Schema scope resolver is the bottleneck.

To resolve the Swagger schema we have to call Pointer::get 1104 times.  First I optimized the pointer, but then I realized we can cut the pointer usage out of that function completely.

```
259 ms → 65.6 ms

Wall Time    65.6ms  -193ms +151.4%
CPU  Time       n/a             n/a
I/O  Time       n/a             n/a
Memory        1.1MB   -432B     n/s
Network         n/a     n/a     n/a
SQL             n/a     n/a
```