### PR TITLE
Fixing bug with stripping fragments

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -51,7 +51,7 @@ function strip_fragment($ref)
 {
     $fragment = Uri\parse($ref)['fragment'];
 
-    return $fragment ? str_replace($fragment, '', $ref) : $ref;
+    return $fragment ? str_replace('#'.$fragment, '#', $ref) : $ref;
 }
 
 /**


### PR DESCRIPTION
If part of the path matches the fragment, it will also be stripped
out of the path. This changes the check to check for the '#' prefix
as well.

Signed-off-by: Nate Brunette <n@tebru.net>