### PR TITLE
Support Windows Paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "sabre/uri": "^1.2.1",
+        "peterpostmann/uri": "^1.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {

--- a/src/Loader/FileLoader.php
+++ b/src/Loader/FileLoader.php
@@ -27,6 +27,9 @@ final class FileLoader implements LoaderInterface
      */
     public function load($path)
     {
+        // file:// + path without query
+        $path = 'file://'.explode('?', $path, 2)[0];
+
         if (!file_exists($path)) {
             throw SchemaLoadingException::notFound($path);
         }

--- a/tests/DereferencerTest.php
+++ b/tests/DereferencerTest.php
@@ -12,7 +12,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_resolves_inline_references()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/inline-ref.json';
+        $path   = __DIR__ . '/fixtures/inline-ref.json';
         $result = $deref->dereference($path);
 
         $this->assertSame(json_encode($result->definitions->address), json_encode($result->properties->billing_address->resolve()));
@@ -22,7 +22,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_resolves_inline_references_when_initial_schema_used_pointer()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/inline-ref.json#/properties/billing_address';
+        $path   = __DIR__ . '/fixtures/inline-ref.json?#/properties/billing_address';
         $result = $deref->dereference($path);
 
         $expected = json_decode(file_get_contents(__DIR__ . '/fixtures/inline-ref.json'));
@@ -69,7 +69,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_resolves_file_remote_references_with_fragments()
     {
         $deref  = new Dereferencer();
-        $path = 'file://' . __DIR__ . '/fixtures/schema.json#/properties';
+        $path = __DIR__ . '/fixtures/schema.json?#/properties';
         $result = $deref->dereference($path);
         $this->assertArrayHasKey('name', (array) $result);
     }
@@ -77,7 +77,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_resolves_recursive_root_pointers()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/recursive-root-pointer.json';
+        $path   = __DIR__ . '/fixtures/recursive-root-pointer.json';
         $result = $deref->dereference($path);
         $this->assertSame(
             $result->properties->foo->additionalProperties,
@@ -88,7 +88,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_resolves_circular_references_to_self()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/circular-ref-self.json';
+        $path   = __DIR__ . '/fixtures/circular-ref-self.json';
         $result = $deref->dereference($path);
 
         $this->assertSame(
@@ -105,7 +105,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_resolves_circular_references_to_parent()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/circular-ref-parent.json';
+        $path   = __DIR__ . '/fixtures/circular-ref-parent.json';
         $result = $deref->dereference($path);
         $ref    = $result
             ->definitions
@@ -121,7 +121,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_resolves_indirect_circular_references()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/circular-ref-indirect.json';
+        $path   = __DIR__ . '/fixtures/circular-ref-indirect.json';
         $result = $deref->dereference($path);
 
         $this->assertSame(
@@ -133,7 +133,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_resolves_references_in_arrays()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/array-ref.json';
+        $path   = __DIR__ . '/fixtures/array-ref.json';
         $result = $deref->dereference($path);
         $this->assertSame($result->items[0], $result->items[1]->resolve());
     }
@@ -141,7 +141,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_dereferences_properties_that_begin_with_a_slash()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/slash-property.json';
+        $path   = __DIR__ . '/fixtures/slash-property.json';
         $result = $deref->dereference($path);
         $slashProperty = '/slash-item';
         $this->assertSame($result->$slashProperty->key, $result->item->key);
@@ -150,7 +150,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_dereferences_properties_with_tilde_in_name()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/tilde-property.json';
+        $path   = __DIR__ . '/fixtures/tilde-property.json';
         $result = $deref->dereference($path);
         $tildeProperty = 'tilde~item';
         $this->assertSame($result->$tildeProperty->key, $result->item->key);
@@ -159,7 +159,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_ignores_references_that_are_not_strings()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/property-named-ref.json';
+        $path   = __DIR__ . '/fixtures/property-named-ref.json';
         $result = $deref->dereference($path);
 
         $this->assertTrue(is_object($result->properties->{'$ref'}));
@@ -176,7 +176,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_resolves_circular_external_references()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/circular-ext-ref.json';
+        $path   = __DIR__ . '/fixtures/circular-ext-ref.json';
         $result = $deref->dereference($path);
         $this->assertInstanceOf(Reference::class, $result->properties->rating);
         $this->assertFalse($result->properties->rating->additionalProperties);
@@ -186,7 +186,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_returns_serializable_schemas()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/inline-ref.json';
+        $path   = __DIR__ . '/fixtures/inline-ref.json';
         $result = $deref->dereference($path);
 
         $this->assertEquals($result, unserialize(serialize($result)));

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -15,12 +15,12 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
             ['otherschema.json', 'http://x.y.z/rootschema.json#', 'http://x.y.z/otherschema.json'],
             ['#bar', 'http://x.y.z/otherschema.json#', 'http://x.y.z/otherschema.json#bar'],
             ['t/inner.json#a', 'http://x.y.z/otherschema.json#', 'http://x.y.z/t/inner.json#a'],
-            ['some://where.else/completely#', 'http://x.y.z/rootschema.json#', 'some://where.else/completely'],
+            ['some://where.else/completely#', 'http://x.y.z/rootschema.json#', 'some://where.else/completely#'],
             ['folderInteger.json', 'http://localhost:1234/folder/', 'http://localhost:1234/folder/folderInteger.json'],
             ['some-id.json', '', 'some-id.json'],
             ['item.json', 'http://some/where/other-item.json', 'http://some/where/item.json'],
             ['item.json', 'file:///schemas/other-item.json', 'file:///schemas/item.json'],
-            ['#', 'file://x.y.z/schema.json', 'file://x.y.z/schema.json']
+            ['#', 'file://x.y.z/schema.json', 'file://x.y.z/schema.json#']
         ];
     }
 


### PR DESCRIPTION
Hi,
I tried to use the library with Windows but it dosn't work. I think the main problem is PHP in this case. `__DIR__` should return a trailing slash on Windows as well, but I think that's not possible for legacy reasons. I'm not sure if PHP is just super inconsistent here or if I'm missing something.

Here is what I found out and how I attempted to fix it:

All files in the test cases and examples are loaded using `'file://' . __DIR__ . '/file.json'` which resolvs to something like `file://C:\folder\subfolder/file.json`. This URI is incorrect for 2 reasons:

- There shouldn't be any backslashes
`parse_url` (which is used by sabre-io/uri) returns false if there are backslashes. The backslashes must be converted to normal slashes. Using the provided examples and test cases on windows causes a `Sabre\Uri\InvalidUriException`
- The format is `file://<host>/<path>` but the host is not present if `__DIR__` returns a path on a drive on Windows (if it returns a path from the network the host is present). The (emtpy) host me added (which results in a third slash after `file:`): `file:///C:/folder/subfolder/file.json`. If the third slash is not added, `parse_url` will interprete this as host:port which results in C:empty. The colon is lost and this information can not be recovered from the result of `parse_url` causing `League\JsonReference\SchemaLoadingException` when external reference is loaded (e.g. file a.sjon references b.json: the loader will try to load `file://c/folder/subfolder/b.json`).

Basically the path provided to the function is wrong. Instead of `'file://' . __DIR__ . '/file.json'`, there should be a logic to correctly determine the host part and convert backslashes. Since this format is used in all test cases, the examples and possible also by everyone else using this lib I think it would be a bad idea to burden this on the user of the library.

Hence I suggest to handle this in the library. Therefore `Derferencer.php prepareArguments` should replace blackslashes and add the missing slash for windows path.

This will result in a different behavior: `functions.php parse_external_ref` will return a path with a trailing slash (`/C:/folder/subfolder/file.json`). This cannot be opened using `file_get_contents`. Therefore the loader must be changed as well. 

The library splitts the URI into prefix and path. But the path is not what `parse_url` returns as path, but more: it includes host, port, username, password if present. Therefore the file loader should handle the path the same way, the CurlWebLoader does it: `$uri = $this->prefix . $path;`

This change would change the way the URI is interpreted, hence it may brake something if the loader is used from other interfaces as well. Therefore I suggest to implement the same change for the loader as well, so that it can handle both paths (`C:/folder/subfolder/file.json` and `/C:/folder/subfolder/file.json`).

This is a breaking change but it may not have any consequences because it only affects the behavior on Windows and the library was not working on Windows anyway in first place.

I don't see a good way to test this. Basically many of the test cases are failing right now, if you run them on Windows.

Looking forward to feedback!

