### PR TITLE
Support multiple decoders

### DIFF
--- a/docs/decoding.md
+++ b/docs/decoding.md
@@ -1,0 +1,67 @@
+---
+layout: default
+title: Decoding
+---
+
+# Decoders
+
+Anytime a schema is decoded it uses a decoder.  Decoders are registered for a specific file extension.  You need to register a decoder for every file type you would like to decode. 
+
+Decoders can also be decorated to add behavior like caching.
+
+## Default Decoders
+
+By default decoders are registered for the file extensions `json`, `yaml`, and `yml` protocols. 
+
+## Available Decoders
+
+### Json Decoder
+
+Decodes schemas from json.
+
+### Yaml Decoder
+
+Decodes schemas from Yaml.
+
+## Custom Decoders
+
+You can make your own decoders by implementing the [Decoder Interface](https://github.com/thephpleague/json-reference/blob/master/src/DecoderInterface.php).
+
+Imagine you may want to decode schemas from a xml document, and your references look like this:
+
+```json
+{ "$ref":"schema.xml" }
+```
+
+You could write a decoder like this:
+
+```php
+class CustomDecoder
+{
+    public function decode($schema)
+    {
+        try {
+            return CustomParser($schema);
+        } catch (CustomParseException $e) {
+            throw new DecodingException(sprintf('Invalid Syntax: %s', $e->getMessage()), $e->getCode(), $e);
+        }
+    }
+}
+```
+
+Once you have written your custom decoder, you can register it.
+
+## Registering Decoders
+
+Decoders are registered with the Loaders's DecoderManager. You register a decoder by passing the extension you would like to decode schemas for and the decoder instance to the `registerDecoder` method.
+
+```php
+<?php
+
+use My\App\CustomDecoder;
+
+$customDecoder = new CustomDecoder();
+$deref  = new League\JsonReference\Dereferencer();
+
+$deref->getLoaderManager()->getDecoderManager()->registerDecoder('xml', $customDecoder);
+```

--- a/src/Decoder/JsonDecoder.php
+++ b/src/Decoder/JsonDecoder.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace League\JsonReference\JsonDecoder;
+namespace League\JsonReference\Decoder;
 
-use League\JsonReference\JsonDecoderInterface;
-use League\JsonReference\JsonDecodingException;
+use League\JsonReference\DecoderInterface;
+use League\JsonReference\DecodingException;
 
-final class JsonDecoder implements JsonDecoderInterface
+final class JsonDecoder implements DecoderInterface
 {
     /**
      * @var bool
@@ -34,17 +34,16 @@ final class JsonDecoder implements JsonDecoderInterface
         $this->options = $options;
     }
 
+    
     /**
-     * @param string $json
-     *
-     * @return object
+     * {@inheritdoc}
      */
-    public function decode($json)
+    public function decode($schema)
     {
-        $data = json_decode($json, $this->assoc, $this->depth, $this->options);
+        $data = json_decode($schema, $this->assoc, $this->depth, $this->options);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new JsonDecodingException(sprintf('Invalid JSON: %s', json_last_error_msg()));
+            throw new DecodingException(sprintf('Invalid JSON: %s', json_last_error_msg()));
         }
 
         return $data;

--- a/src/Decoder/YamlDecoder.php
+++ b/src/Decoder/YamlDecoder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace League\JsonReference\Decoder;
+
+use League\JsonReference\DecoderInterface;
+use League\JsonReference\DecodingException;
+
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+final class YamlDecoder implements DecoderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function decode($schema)
+    {
+        try {
+            return Yaml::parse($schema, Yaml::PARSE_OBJECT_FOR_MAP | Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE);
+        } catch (ParseException $e) {
+            throw new DecodingException(sprintf('Invalid Yaml: %s', $e->getMessage()), $e->getCode(), $e);
+        }
+    }
+}

--- a/src/DecoderInterface.php
+++ b/src/DecoderInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace League\JsonReference;
+
+interface DecoderInterface
+{
+    /**
+     * @param string $schema
+     *
+     * @return object
+     *
+     * @throws DecodingException
+     */
+    public function decode($schema);
+}

--- a/src/DecoderManager.php
+++ b/src/DecoderManager.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace League\JsonReference;
+
+use League\JsonReference\Decoder\JsonDecoder;
+use League\JsonReference\Decoder\YamlDecoder;
+
+final class DecoderManager
+{
+
+    
+    /**
+     * @var ParserInterface[]
+     */
+    private $decoders = [];
+
+    /**
+     * @var bool
+     */
+    private $ignoreUnknownExtension = [];
+
+    /**
+     * @param DecoderInterface[] $decoders
+     */
+    public function __construct(array $decoders = [], $ignoreUnknownExtension = true)
+    {
+        if (empty($decoders)) {
+            $this->registerDefaultDecoder();
+        }
+        
+        foreach ($decoders as $extension => $decoder) {
+            $this->registerDecoder($extension, $decoder);
+        }
+
+        $this->ignoreUnknownExtension = $ignoreUnknownExtension;
+    }
+
+    /**
+     * Register a DecoderInterface for the given extension.
+     *
+     * @param DecoderInterface $decoder
+     */
+    public function registerDecoder($extension, DecoderInterface $decoder)
+    {
+        $this->decoders[$extension] = $decoder;
+    }
+
+    /**
+     * Get all registered decoders, keyed by the extensions they are registered to decode schemas for.
+     *
+     * @return DecoderInterface[]
+     */
+    public function getDecoders()
+    {
+        return $this->decoders;
+    }
+
+    /**
+     * Set to true to use default decoder for unknown file extensions
+     *
+     * @param bool
+     */
+    public function setIgnoreUnknownExtension($ignoreUnknownExtension)
+    {
+        $this->ignoreUnknownExtension = $ignoreUnknownExtension;
+    }
+
+    /**
+     * Get the decoder for the given extension.
+     *
+     * @param string $extension
+     *
+     * @return DecoderInterface
+     * @throws \InvalidArgumentException
+     */
+    public function getDecoder($extension)
+    {
+        if (!$this->hasDecoder($extension)) {
+            if ($this->ignoreUnknownExtension) {
+                $extension = 'json';
+            } else {
+                throw new \InvalidArgumentException(
+                    sprintf('A decoder is not registered for the extension "%s"', $extension)
+                );
+            }
+        }
+
+        return $this->decoders[$extension];
+    }
+    
+    /**
+     * @param string $extension
+     *
+     * @return bool
+     */
+    public function hasDecoder($extension)
+    {
+        return isset($this->decoders[$extension]);
+    }
+
+    /**
+     * Register the default decoder.
+     */
+    private function registerDefaultDecoder()
+    {
+        $this->registerDecoder('json', new JsonDecoder());
+        $this->registerDecoder('yaml', new YamlDecoder());
+        $this->registerDecoder('yml', $this->decoders['yaml']);
+    }
+}

--- a/src/DecodingException.php
+++ b/src/DecodingException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace League\JsonReference;
+
+final class DecodingException extends \RuntimeException
+{
+}

--- a/src/Dereferencer.php
+++ b/src/Dereferencer.php
@@ -65,10 +65,14 @@ final class Dereferencer implements DereferencerInterface
      */
     public function dereference($schema, $uri = '')
     {
-        return $this->crawl($schema, $uri, function ($schema, $pointer, $ref, $scope) {
-            $resolved = new Reference($ref, $scope, is_internal_ref($ref) ? $schema : null);
-            return merge_ref($schema, $resolved, $pointer);
-        });
+        return $this->crawl(
+            $schema,
+            $uri,
+            function ($schema, $pointer, $ref, $scope) {
+                $resolved = new Reference($ref, $scope, is_internal_ref($ref) ? $schema : null);
+                return merge_ref($schema, $resolved, $pointer);
+            }
+        );
     }
 
     /**

--- a/src/DereferencerInterface.php
+++ b/src/DereferencerInterface.php
@@ -13,7 +13,7 @@ interface DereferencerInterface
      * @param string|object $schema Either a valid path like "http://json-schema.org/draft-03/schema#"
      *                              or the object resulting from a json_decode call.
      *
-     * @param string $uri
+     * @param string        $uri
      *
      * @return object
      */

--- a/src/JsonDecoderInterface.php
+++ b/src/JsonDecoderInterface.php
@@ -2,14 +2,9 @@
 
 namespace League\JsonReference;
 
-interface JsonDecoderInterface
+/**
+ * Legacy
+ */
+interface JsonDecoderInterface extends DecoderInterface
 {
-    /**
-     * @param string $json
-     *
-     * @return object
-     *
-     * @throws JsonDecodingException
-     */
-    public function decode($json);
 }

--- a/src/JsonDecodingException.php
+++ b/src/JsonDecodingException.php
@@ -2,7 +2,5 @@
 
 namespace League\JsonReference;
 
-final class JsonDecodingException extends \RuntimeException
-{
-
-}
+// Legacy
+class_alias('DecodingException', 'JsonDecodingException');

--- a/src/LoaderManager.php
+++ b/src/LoaderManager.php
@@ -2,6 +2,7 @@
 
 namespace League\JsonReference;
 
+use League\JsonReference\DecoderManager;
 use League\JsonReference\Loader\CurlWebLoader;
 use League\JsonReference\Loader\FileGetContentsWebLoader;
 use League\JsonReference\Loader\FileLoader;
@@ -12,16 +13,24 @@ final class LoaderManager
      * @var LoaderInterface[]
      */
     private $loaders = [];
+    
+    /**
+     * @var DecoderManager
+     */
+    private $decoderManager = [];
 
     /**
      * @param LoaderInterface[] $loaders
      */
-    public function __construct(array $loaders = [])
+    public function __construct(array $loaders = [], DecoderManager $decoderManager = null)
     {
         if (empty($loaders)) {
             $this->registerDefaultFileLoader();
             $this->registerDefaultWebLoaders();
-            return;
+        }
+        
+        if (empty($decoderManager)) {
+            $this->decoderManager = new DecoderManager();
         }
 
         foreach ($loaders as $prefix => $loader) {
@@ -84,7 +93,7 @@ final class LoaderManager
     {
         $this->loaders['file'] = new FileLoader();
     }
-
+    
     /**
      * Register the default web loaders.  If the curl extension is loaded,
      * the CurlWebLoader will be used.  Otherwise the FileGetContentsWebLoader
@@ -100,5 +109,25 @@ final class LoaderManager
             $this->loaders['https'] = new FileGetContentsWebLoader('https://');
             $this->loaders['http']  = new FileGetContentsWebLoader('http://');
         }
+    }
+
+    /**
+     * @return DecoderManager
+     */
+    public function getDecoderManager()
+    {
+        return $this->decoderManager;
+    }
+
+    /**
+     * @param \League\JsonReference\DecoderManager $decoderManager
+     *
+     * @return \League\JsonReference\LoaderManager
+     */
+    public function setDecoderManager(DecoderManager $decoderManager)
+    {
+        $this->decoderManager = $decoderManager;
+
+        return $this;
     }
 }

--- a/tests/Decoder/JsonDecoderTest.php
+++ b/tests/Decoder/JsonDecoderTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace League\JsonReference\Test\Loader;
+
+use League\JsonReference\Decoder\JsonDecoder;
+use League\JsonReference\DecodingException;
+
+class JsonDecoderTest extends \PHPUnit_Framework_TestCase
+{
+    function test_it_decodes()
+    {
+        $schema =  <<<'JSON'
+{
+    "type": "object",
+    "properties": {
+        "street_address": { "type": "string" },
+        "city":           { "type": "string" },
+        "state":          { "type": "string" }
+    },
+    "required": ["street_address", "city", "state"]
+}
+JSON;
+
+        $expectedObject = (object) [
+            'type' => 'object',
+            'properties' => (object) [
+                'street_address' => (object) [ 'type' => 'string' ],
+                'city'           => (object) [ 'type' => 'string' ],
+                'state'          => (object) [ 'type' => 'string' ],
+            ],
+            'required' => ['street_address', 'city', 'state']
+        ];
+
+        $decoder = new JsonDecoder();
+        $this->assertEquals($expectedObject, $decoder->decode($schema));
+    }
+}

--- a/tests/Decoder/YamlDecoerTest.php
+++ b/tests/Decoder/YamlDecoerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace League\JsonReference\Test\Loader;
+
+use League\JsonReference\Decoder\YamlDecoder;
+use League\JsonReference\DecodingException;
+
+class YamlDecoderTest extends \PHPUnit_Framework_TestCase
+{
+    function test_it_decodes()
+    {
+        $schema = <<<'YAML'
+type: object
+properties: 
+    street_address: 
+        type: string
+    city:
+        type: string
+    state:
+        type: string
+required: 
+    - street_address
+    - city
+    - state
+YAML;
+
+        $expectedObject = (object) [
+            'type' => 'object',
+            'properties' => (object) [
+                'street_address' => (object) [ 'type' => 'string' ],
+                'city'           => (object) [ 'type' => 'string' ],
+                'state'          => (object) [ 'type' => 'string' ],
+            ],
+            'required' => ['street_address', 'city', 'state']
+        ];
+
+        $decoder = new YamlDecoder();
+        $this->assertEquals($expectedObject, $decoder->decode($schema));
+    }
+}

--- a/tests/DecoderManagerTest.php
+++ b/tests/DecoderManagerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace League\JsonReference\Test;
+
+use League\JsonReference\Decoder\JsonDecoder;
+use League\JsonReference\Decoder\YamlDecoder;
+use League\JsonReference\DecoderInterface;
+use League\JsonReference\DecoderManager;
+
+class DecoderManagerTest extends \PHPUnit_Framework_TestCase
+{
+    function test_can_get_all_decoders_indexed_by_prefix()
+    {
+        $manager = new DecoderManager();
+        $decoders = $manager->getDecoders();
+        $this->assertArrayHasKey('json', $decoders);
+        $this->assertInstanceOf(DecoderInterface::class, $decoders['json']);
+        $this->assertArrayHasKey('yaml', $decoders);
+        $this->assertInstanceOf(DecoderInterface::class, $decoders['yaml']);
+        $this->assertArrayHasKey('yml', $decoders);
+        $this->assertInstanceOf(DecoderInterface::class, $decoders['yml']);
+    }
+
+    function test_getDecoder_uses_default_decoder_when_the_decoder_does_not_exist()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+        $manager = new DecoderManager([], false);
+        $manager->getDecoder('xml');
+    }
+
+    function test_getDecoder_throws_when_the_decoder_does_not_exist_and_ignore_unknown_extension_is_true()
+    {
+        $manager = new DecoderManager([], true);
+        $this->assertInstanceOf(DecoderInterface::class, $manager->getDecoder('dummy'));
+    }
+
+    function test_can_register_decoder()
+    {
+        $decoder  = new JsonDecoder();
+        $manager = new DecoderManager();
+        $manager->registerDecoder('dummy', $decoder);
+        $this->assertSame($decoder, $manager->getDecoder('dummy'));
+    }
+
+    function test_it_doesnt_use_defaults_if_decoders_are_provided()
+    {
+        $decoders  = [
+            'dummy' => new JsonDecoder()
+        ];
+
+        $manager = new DecoderManager($decoders);
+
+        $this->assertFalse($manager->hasDecoder('json'));
+        $this->assertFalse($manager->hasDecoder('yaml'));
+        $this->assertFalse($manager->hasDecoder('yml'));
+        $this->assertTrue($manager->hasDecoder('dummy'));
+    }
+}

--- a/tests/DereferencerTest.php
+++ b/tests/DereferencerTest.php
@@ -6,6 +6,7 @@ use League\JsonReference\Dereferencer;
 use League\JsonReference\Loader\ArrayLoader;
 use League\JsonReference\Pointer;
 use League\JsonReference\Reference;
+use League\JsonReference\LoaderManager;
 
 class DereferencerTest extends \PHPUnit_Framework_TestCase
 {
@@ -48,6 +49,14 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     {
         $deref  = new Dereferencer();
         $result = $deref->dereference('http://localhost:1234/albums.json');
+
+        $this->assertSame('string', $result->items->properties->title->type);
+    }
+    
+    function test_it_resolves_mixed_references()
+    {
+        $deref  = new Dereferencer();
+        $result = $deref->dereference('http://localhost:1234/albums.yaml');
 
         $this->assertSame('string', $result->items->properties->title->type);
     }
@@ -190,5 +199,11 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
         $result = $deref->dereference($path);
 
         $this->assertEquals($result, unserialize(serialize($result)));
+    }
+    
+    function test_it_returns_loader_manager()
+    {
+        $deref  = new Dereferencer();
+        $this->assertInstanceOf(LoaderManager::class, $deref->getLoaderManager());       
     }
 }

--- a/tests/LoaderManagerTest.php
+++ b/tests/LoaderManagerTest.php
@@ -5,6 +5,7 @@ namespace League\JsonReference\Test;
 use League\JsonReference\Loader\ArrayLoader;
 use League\JsonReference\LoaderInterface;
 use League\JsonReference\LoaderManager;
+use League\JsonReference\DecoderManager;
 
 class LoaderManagerTest extends \PHPUnit_Framework_TestCase
 {
@@ -47,5 +48,11 @@ class LoaderManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($manager->hasLoader('http'));
         $this->assertFalse($manager->hasLoader('https'));
         $this->assertTrue($manager->hasLoader('array'));
+    }
+    
+    function test_it_returns_decoder_manager()
+    {
+        $loaderManager  = new LoaderManager();
+        $this->assertInstanceOf(DecoderManager::class, $loaderManager->getDecoderManager());       
     }
 }

--- a/tests/fixtures/remotes/albums.yaml
+++ b/tests/fixtures/remotes/albums.yaml
@@ -1,0 +1,3 @@
+type: array
+items:
+    $ref: album.json


### PR DESCRIPTION
Hi,

I added support to handle multiple decoders and added a Yaml decoder.

A `DecoderManager` is passed to the Loaders which manages the file extension which can be decoded (json, yaml, yml). It defaults to json. Multiple Decoders which implement `DecoderInterface` can be added to the the `DecoderManager`.

The `DecoderManager` has an option to ignore unknown extension. If set to true, unknown extensions are decoded with the Jsondecoder, if set to false, they cause an `InvalidArgumentException`.

This change is backward compatible:
- Decoding errors cause a `DecoderException`. `JsonDecoderException `is an alias of this class. 
- `JsonDecoderInterface` still exists. A `JsonDecoderInterface` or `DecoderInterface` can be passed instead of a `DecoderManager`. 


