### PR TITLE
Load files using fileuri

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
         "sabre/uri": "^1.2.1",
         "psr/simple-cache": "^1.0"
     },
+    "suggest": {
+        "peterpostmann/fileuri": "Returns a file uri from a path"
+    },
     "require-dev": {
         "phpunit/phpunit" : "^5.7",
         "scrutinizer/ocular": "~1.1",
@@ -29,7 +32,8 @@
         "cache/simple-cache-bridge": "^0.1.0",
         "cache/array-adapter": "^0.4.2",
         "phpbench/phpbench": "^0.13.0",
-        "cache/predis-adapter": "^0.4.0"
+        "cache/predis-adapter": "^0.4.0",
+        "peterpostmann/fileuri": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Loader/FileLoader.php
+++ b/src/Loader/FileLoader.php
@@ -27,10 +27,12 @@ final class FileLoader implements LoaderInterface
      */
     public function load($path)
     {
-        if (!file_exists($path)) {
-            throw SchemaLoadingException::notFound($path);
+        $uri = 'file://' . $path;
+        
+        if (!file_exists($uri)) {
+            throw SchemaLoadingException::notFound($uri);
         }
 
-        return $this->jsonDecoder->decode(file_get_contents($path));
+        return $this->jsonDecoder->decode(file_get_contents($uri));
     }
 }

--- a/tests/CachedDereferencerTest.php
+++ b/tests/CachedDereferencerTest.php
@@ -6,6 +6,7 @@ use Cache\Adapter\PHPArray\ArrayCachePool;
 use Cache\Bridge\SimpleCache\SimpleCacheBridge;
 use League\JsonReference\CachedDereferencer;
 use League\JsonReference\Dereferencer;
+use function peterpostmann\uri\fileuri;
 
 class CachedDereferencerTest extends \PHPUnit_Framework_TestCase
 {
@@ -14,7 +15,7 @@ class CachedDereferencerTest extends \PHPUnit_Framework_TestCase
         $cache  = new ArrayCachePool();
         $cache  = new SimpleCacheBridge($cache);
         $deref  = new CachedDereferencer(new Dereferencer(), $cache);
-        $path   = 'file://' . __DIR__ . '/fixtures/inline-ref.json';
+        $path   = fileuri('fixtures/inline-ref.json', __DIR__);
         $result = $deref->dereference($path);
 
         $this->assertSame($result, $cache->get(sha1($path)));
@@ -37,7 +38,7 @@ class CachedDereferencerTest extends \PHPUnit_Framework_TestCase
         $cache  = new SimpleCacheBridge($cache);
         $deref  = new CachedDereferencer(new Dereferencer(), $cache);
         $schema = json_decode(file_get_contents(__DIR__ . '/fixtures/inline-ref.json'));
-        $path   = 'file://' . __DIR__ . '/fixtures/inline-ref.json';
+        $path   = fileuri('fixtures/inline-ref.json', __DIR__);
         $result = $deref->dereference($schema, $path);
 
         $this->assertSame($result, $cache->get(sha1($path)));

--- a/tests/DereferencerTest.php
+++ b/tests/DereferencerTest.php
@@ -6,13 +6,14 @@ use League\JsonReference\Dereferencer;
 use League\JsonReference\Loader\ArrayLoader;
 use League\JsonReference\Pointer;
 use League\JsonReference\Reference;
+use function peterpostmann\uri\fileuri;
 
 class DereferencerTest extends \PHPUnit_Framework_TestCase
 {
     function test_it_resolves_inline_references()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/inline-ref.json';
+        $path   = fileuri('fixtures/inline-ref.json', __DIR__);
         $result = $deref->dereference($path);
 
         $this->assertSame(json_encode($result->definitions->address), json_encode($result->properties->billing_address->resolve()));
@@ -22,7 +23,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_resolves_inline_references_when_initial_schema_used_pointer()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/inline-ref.json#/properties/billing_address';
+        $path   = fileuri('fixtures/inline-ref.json', __DIR__).'#/properties/billing_address';
         $result = $deref->dereference($path);
 
         $expected = json_decode(file_get_contents(__DIR__ . '/fixtures/inline-ref.json'));
@@ -69,7 +70,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_resolves_file_remote_references_with_fragments()
     {
         $deref  = new Dereferencer();
-        $path = 'file://' . __DIR__ . '/fixtures/schema.json#/properties';
+        $path = fileuri('fixtures/schema.json', __DIR__).'#/properties';
         $result = $deref->dereference($path);
         $this->assertArrayHasKey('name', (array) $result);
     }
@@ -77,7 +78,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_resolves_recursive_root_pointers()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/recursive-root-pointer.json';
+        $path   = fileuri('fixtures/recursive-root-pointer.json', __DIR__);
         $result = $deref->dereference($path);
         $this->assertSame(
             $result->properties->foo->additionalProperties,
@@ -88,7 +89,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_resolves_circular_references_to_self()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/circular-ref-self.json';
+        $path   = fileuri('fixtures/circular-ref-self.json', __DIR__);
         $result = $deref->dereference($path);
 
         $this->assertSame(
@@ -105,7 +106,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_resolves_circular_references_to_parent()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/circular-ref-parent.json';
+        $path   = fileuri('fixtures/circular-ref-parent.json', __DIR__);
         $result = $deref->dereference($path);
         $ref    = $result
             ->definitions
@@ -121,7 +122,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_resolves_indirect_circular_references()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/circular-ref-indirect.json';
+        $path   = fileuri('fixtures/circular-ref-indirect.json', __DIR__);
         $result = $deref->dereference($path);
 
         $this->assertSame(
@@ -133,7 +134,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_resolves_references_in_arrays()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/array-ref.json';
+        $path   = fileuri('fixtures/array-ref.json', __DIR__);
         $result = $deref->dereference($path);
         $this->assertSame($result->items[0], $result->items[1]->resolve());
     }
@@ -141,7 +142,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_dereferences_properties_that_begin_with_a_slash()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/slash-property.json';
+        $path   = fileuri('fixtures/slash-property.json', __DIR__);
         $result = $deref->dereference($path);
         $slashProperty = '/slash-item';
         $this->assertSame($result->$slashProperty->key, $result->item->key);
@@ -150,7 +151,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_dereferences_properties_with_tilde_in_name()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/tilde-property.json';
+        $path   = fileuri('fixtures/tilde-property.json', __DIR__);
         $result = $deref->dereference($path);
         $tildeProperty = 'tilde~item';
         $this->assertSame($result->$tildeProperty->key, $result->item->key);
@@ -159,7 +160,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_ignores_references_that_are_not_strings()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/property-named-ref.json';
+        $path   = fileuri('fixtures/property-named-ref.json', __DIR__);
         $result = $deref->dereference($path);
 
         $this->assertTrue(is_object($result->properties->{'$ref'}));
@@ -176,7 +177,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_resolves_circular_external_references()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/circular-ext-ref.json';
+        $path   = fileuri('fixtures/circular-ext-ref.json', __DIR__);
         $result = $deref->dereference($path);
         $this->assertInstanceOf(Reference::class, $result->properties->rating);
         $this->assertFalse($result->properties->rating->additionalProperties);
@@ -186,7 +187,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     function test_it_returns_serializable_schemas()
     {
         $deref  = new Dereferencer();
-        $path   = 'file://' . __DIR__ . '/fixtures/inline-ref.json';
+        $path   = fileuri('fixtures/inline-ref.json', __DIR__);
         $result = $deref->dereference($path);
 
         $this->assertEquals($result, unserialize(serialize($result)));

--- a/tests/ReferenceSerializer/InlineReferenceSerializerTest.php
+++ b/tests/ReferenceSerializer/InlineReferenceSerializerTest.php
@@ -5,13 +5,14 @@ namespace League\JsonReference\Test\ReferenceSerializer;
 use League\JsonReference\Dereferencer;
 use League\JsonReference\ReferenceSerializationException;
 use League\JsonReference\ReferenceSerializer\InlineReferenceSerializer;
+use function peterpostmann\uri\fileuri;
 
 class InlineReferenceSerializerTest extends \PHPUnit_Framework_TestCase
 {
     function test_it_inlines_inline_references()
     {
         $deref  = (new Dereferencer())->setReferenceSerializer(new InlineReferenceSerializer());
-        $path   = 'file://' . __DIR__ . '/../fixtures/inline-ref.json';
+        $path   = fileuri('../fixtures/inline-ref.json', __DIR__);
         $result = json_decode(json_encode($deref->dereference($path)), true);
 
         $this->assertSame('object', $result['properties']['billing_address']['type']);
@@ -32,14 +33,14 @@ class InlineReferenceSerializerTest extends \PHPUnit_Framework_TestCase
             $this->expectException(ReferenceSerializationException::class);
         }
         $deref  = (new Dereferencer())->setReferenceSerializer(new InlineReferenceSerializer());
-        $path   = 'file://' . __DIR__ . '/../fixtures/circular-ref-self.json';
+        $path   = fileuri('../fixtures/circular-ref-self.json', __DIR__);
         json_encode($deref->dereference($path));
     }
 
     function test_it_does_not_throw_when_serializing_indirect_circular_references()
     {
         $deref  = (new Dereferencer())->setReferenceSerializer(new InlineReferenceSerializer());
-        $path   = 'file://' . __DIR__ . '/../fixtures/circular-ref-indirect.json';
+        $path   = fileuri('../fixtures/circular-ref-indirect.json', __DIR__);
         $this->assertFalse(json_encode($deref->dereference($path)));
         $this->assertSame(JSON_ERROR_RECURSION, json_last_error());
     }


### PR DESCRIPTION
Hi,

as discussed in #11 these are the tests using fileuri and the needed changes to the loader. 

The `test_it_resolves_circular_external_references`-Test will still fail on Windows, cause there is an issue in sabre/uri (see https://github.com/sabre-io/uri/pull/25). All other tests pass.