### PR TITLE
Introduce DecoderManager

### DIFF
--- a/docs/decoding.md
+++ b/docs/decoding.md
@@ -5,7 +5,7 @@ title: Decoding
 
 # Decoders
 
-Anytime a schema is decoded it uses a decoder. Decoders are registered for a specific file extension. You need to register the proper decoder for the file type you would like to decode. 
+Anytime a schema is decoded it uses a decoder. Decoders are registered for a specific media type. You need to register a decoder for every type you would like to decode. 
 
 Decoders can also be decorated to add behavior like caching.
 
@@ -20,7 +20,7 @@ By default the 'json' decoder is used.
 
 ## Custom Decoders
 
-You can make your own decoders by implementing the [Decoder Interface](https://github.com/thephpleague/json-reference/blob/master/src/DecoderInterface.php).
+You can create your own decoders by implementing the [Decoder Interface](https://github.com/thephpleague/json-reference/blob/master/src/DecoderInterface.php).
 
 Imagine you may want to decode schemas from a xml document, and your references look like this:
 
@@ -48,7 +48,7 @@ Once you have written your custom decoder, you can register it.
 
 ## Registering Decoders
 
-Decoders are registered in the Loaders's constructor. You register a decoder by passing an instance.
+Decoders are registered with the Loaders's DecoderManager. You register a decoder by passing the extension you would like to decode schemas for and the decoder instance to the `registerDecoder` method.
 
 ```php
 <?php
@@ -59,5 +59,21 @@ $decoder = new CustomDecoder();
 $loader  = new FileLoader($decoder);
 $deref   = new League\JsonReference\Dereferencer();
 
-$deref->getLoaderManager()->registerLoader('file', $loader);
+$deref->getLoaderManager()->getDecoderManager()->registerDecoder('xyz', $customDecoder);
 ```
+
+### Media Types
+
+The decoder manager determines the decoder based on the Content-Type header (first priority) or file extension (second priority). 
+
+
+| Content-Type Header | File Extension | Evaluated Type |
+| ------------------- | -------------- | -------------- |
+| xxx/yyy             |                | xxx/yyy        |
+| xxx/yyy+zzz         |                | +zzz           |
+| xxx/yyy+zzz         | foo.bar        | +zzz           |
+| xxx/yyy             | foo.bar        | xxx/yyy        |
+|                     | foo.bar        | bar            |
+|                     |                | null           |
+
+If the suffix of a sub-type is used, a '+'-sign is used to distinguishe between suffixes and file extensions.

--- a/src/DecoderManager.php
+++ b/src/DecoderManager.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace League\JsonReference;
+
+use League\JsonReference\Decoder\JsonDecoder;
+use League\JsonReference\Decoder\YamlDecoder;
+
+final class DecoderManager
+{
+    /**
+     * @var ParserInterface[]
+     */
+    private $decoders = [];
+
+    /**
+     * @param DecoderInterface[] $decoders
+     * @param string $defaultType
+     */
+    public function __construct(array $decoders = [], $defaultType = null)
+    {
+        if (empty($decoders)) {
+            $this->registerDefaultDecoders();
+            
+            // Backwards compatibilty
+            if ($defaultType === null) {
+                $defaultType = 'json';
+            }
+        } else {
+            foreach ($decoders as $type => $decoder) {
+                $this->registerDecoder($type, $decoder);
+            }
+        }
+
+        if ($defaultType) {
+            $this->setDefaultType($defaultType);
+        }
+    }
+
+    /**
+     * Register a DecoderInterface for the given MIME-types.
+     *
+     * @param string $type
+     * @param DecoderInterface $decoder
+     */
+    public function registerDecoder($type, DecoderInterface $decoder = null)
+    {
+        if ($decoder) {
+            $this->decoders[$type] = $decoder;
+        } else {
+            unset($this->decoders[$type]);
+        }
+    }
+
+    /**
+     * Get all registered decoders, keyed by the extensions they are registered to decode schemas for.
+     *
+     * @return DecoderInterface[]
+     */
+    public function getDecoders()
+    {
+        return $this->decoders;
+    }
+
+    /**
+     * Set the default type for unknown files
+     *
+     * @param string defaultType
+     */
+    public function setDefaultType($defaultType = null)
+    {
+        $this->registerDecoder(null, $defaultType ? $this->getDecoder($defaultType) : null);
+    }
+
+    /**
+     * Get the decoder for the given extension.
+     *
+     * @param string $type
+     *
+     * @return DecoderInterface
+     * @throws \InvalidArgumentException
+     */
+    public function getDecoder($type)
+    {
+        if (!$this->hasDecoder($type)) {
+            if ($this->hasDecoder(null)) {
+                $type = null;
+            } else {
+                throw new \InvalidArgumentException(
+                    sprintf('A decoder is not registered for the extension "%s"', $type)
+                );
+            }
+        }
+
+        return $this->decoders[$type];
+    }
+    
+    /**
+     * @param string $type
+     *
+     * @return bool
+     */
+    public function hasDecoder($type)
+    {
+        return isset($this->decoders[$type]);
+    }
+
+    /**
+     * Register the default decoders
+     */
+    private function registerDefaultDecoders()
+    {
+        $this->registerJsonDecoder();
+    }
+
+    /**
+     * @param DecoderInterface $decoder
+     */
+    public function registerJsonDecoder(DecoderInterface $decoder = null)
+    {
+        $decoder = $decoder ?: new JsonDecoder();
+
+        $this->registerDecoder('json', $decoder);
+        $this->registerDecoder('text/json', $decoder);
+        $this->registerDecoder('application/json', $decoder);
+        $this->registerDecoder('+json', $decoder);
+    }
+
+    /**
+     * @param DecoderInterface $decoder
+     */
+    public function registerYamlDecoder(DecoderInterface $decoder = null)
+    {
+        $decoder = $decoder ?: new YamlDecoder();
+
+        $this->registerDecoder('yml', $decoder);
+        $this->registerDecoder('yaml', $decoder);
+        $this->registerDecoder('text/yaml', $decoder);
+        $this->registerDecoder('application/x-yaml', $decoder);
+        $this->registerDecoder('+yaml', $decoder);
+    }
+}

--- a/src/Loader/FileLoader.php
+++ b/src/Loader/FileLoader.php
@@ -2,24 +2,29 @@
 
 namespace League\JsonReference\Loader;
 
-use League\JsonReference\Decoder\JsonDecoder;
+use League\JsonReference\DecoderManager;
 use League\JsonReference\DecoderInterface;
 use League\JsonReference\LoaderInterface;
 use League\JsonReference\SchemaLoadingException;
+use function League\JsonReference\determineMediaType;
 
 final class FileLoader implements LoaderInterface
 {
     /**
-     * @var DecoderInterface
+     * @var DecoderManager
      */
-    private $jsonDecoder;
+    private $decoderManager;
 
     /**
-     * @param DecoderInterface $jsonDecoder
+     * @param DecoderInterface|DecoderManager $decoderManager
      */
-    public function __construct(DecoderInterface $jsonDecoder = null)
+    public function __construct($decoderManager = null)
     {
-        $this->jsonDecoder = $jsonDecoder ?: new JsonDecoder();
+        if ($decoderManager instanceof DecoderInterface) {
+            $this->decoderManager = new DecoderManager([null => $decoderManager]);
+        } else {
+            $this->decoderManager = $decoderManager ?: new DecoderManager();
+        }
     }
 
     /**
@@ -33,6 +38,7 @@ final class FileLoader implements LoaderInterface
             throw SchemaLoadingException::notFound($uri);
         }
 
-        return $this->jsonDecoder->decode(file_get_contents($uri));
+        $type = determineMediaType(['uri' => $uri]);
+        return $this->decoderManager->getDecoder($type)->decode(file_get_contents($uri));
     }
 }

--- a/tests/DecoderManagerTest.php
+++ b/tests/DecoderManagerTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace League\JsonReference\Test;
+
+use League\JsonReference\Decoder\JsonDecoder;
+use League\JsonReference\Decoder\YamlDecoder;
+use League\JsonReference\DecoderInterface;
+use League\JsonReference\DecoderManager;
+
+class DecoderManagerTest extends \PHPUnit_Framework_TestCase
+{
+    function default_decoder()
+    {
+        $manager = new DecoderManager();
+
+        return [
+            ['json', $manager],
+            ['text/json', $manager],
+            ['application/json', $manager],
+            ['+json', $manager],
+        ];        
+    }
+
+    function json_decoder()
+    {
+        $manager = new DecoderManager();
+        $manager->registerJsonDecoder();
+
+        return [
+            ['json', $manager],
+            ['text/json', $manager],
+            ['application/json', $manager],
+            ['+json', $manager],
+        ];
+    }
+
+    function yaml_decoder()
+    {
+        $manager = new DecoderManager();
+        $manager->registerYamlDecoder();
+        
+        return [
+            ['yml', $manager],
+            ['yaml', $manager],
+            ['text/yaml', $manager],
+            ['application/x-yaml', $manager],
+            ['+yaml', $manager],
+        ];
+    }
+
+    /**
+     * @dataProvider default_decoder
+     * @dataProvider json_decoder
+     * @dataProvider yaml_decoder
+     */
+    function test_decoder_presence($key, $manager)
+    {
+        $decoders = $manager->getDecoders();
+        $this->assertArrayHasKey($key, $decoders);
+        $this->assertInstanceOf(DecoderInterface::class, $decoders[$key]);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    function test_getDecoder_throws_when_the_decoder_does_not_exist_and_no_default_decoder_is_set()
+    {
+        $manager = new DecoderManager();
+        $manager->setDefaultType(null);
+        $manager->getDecoder('dummy');
+    }
+
+    function test_getDecoder_uses_default_decoder_when_the_decoder_does_not_exist()
+    {
+        $manager = new DecoderManager([], 'json');
+        $this->assertInstanceOf(DecoderInterface::class, $manager->getDecoder('dummy'));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    function test_getDecoder_fails_if_no_default_exist()
+    {
+        $manager = new DecoderManager([], 'json');
+        $manager->setDefaultType(null);
+        $manager->getDecoder('dummy');
+    }
+
+    function test_can_register_decoder()
+    {
+        $decoder  = new JsonDecoder();
+        $manager = new DecoderManager();
+        $manager->registerDecoder('dummy', $decoder);
+        $this->assertSame($decoder, $manager->getDecoder('dummy'));
+    }
+
+    function test_it_doesnt_use_defaults_if_decoders_are_provided()
+    {
+        $decoders  = [
+            'dummy' => new JsonDecoder()
+        ];
+
+        $manager = new DecoderManager($decoders);
+
+        $this->assertFalse($manager->hasDecoder('json'));
+        $this->assertTrue($manager->hasDecoder('dummy'));
+    }
+}

--- a/tests/DereferencerTest.php
+++ b/tests/DereferencerTest.php
@@ -52,6 +52,15 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('string', $result->items->properties->title->type);
     }
+    
+    function test_it_resolves_mixed_references()
+    {
+        $deref  = new Dereferencer();
+        $deref->getLoaderManager()->getDecoderManager()->registerYamlDecoder();
+        $result = $deref->dereference('http://localhost:1234/albums.yaml');
+
+        $this->assertSame('string', $result->items->properties->title->type);
+    }
 
     function test_it_fails_when_resolving_a_remote_reference_without_id_or_uri()
     {

--- a/tests/Loader/ArrayLoaderTest.php
+++ b/tests/Loader/ArrayLoaderTest.php
@@ -33,4 +33,16 @@ class ArrayLoaderTest extends \PHPUnit_Framework_TestCase
         ]);
         $loader->load('bad/type');
     }
+
+    function test_constructor_accepts_decoder_interface() 
+    {
+        $schemas = [
+            'string/schema' => 'type: string'
+        ];
+
+        $decoder = new \League\JsonReference\Decoder\YamlDecoder;
+        $loader  = new \League\JsonReference\Loader\ArrayLoader($schemas, $decoder);
+
+        $this->assertEquals((object) ['type'=>'string'], $loader->load('string/schema'));
+    }
 }

--- a/tests/Loader/CurlWebLoaderTest.php
+++ b/tests/Loader/CurlWebLoaderTest.php
@@ -27,4 +27,13 @@ class CurlWebLoaderTest extends \PHPUnit_Framework_TestCase
         $loader = new CurlWebLoader('http://');
         $loader->load('localhost:1234/unknown');
     }
+    
+    function test_constructor_accepts_decoder_interface() 
+    {
+        $decoder  = new \League\JsonReference\Decoder\YamlDecoder;
+        $loader   = new CurlWebLoader('http://', null, $decoder);
+        $response = $loader->load('localhost:1234/string.yaml');
+
+        $this->assertEquals((object) ['type'=>'string'], $response);
+    }
 }

--- a/tests/Loader/FileGetContentsWebLoaderTest.php
+++ b/tests/Loader/FileGetContentsWebLoaderTest.php
@@ -30,4 +30,52 @@ class FileGetContentsWebLoaderTest extends \PHPUnit_Framework_TestCase
         $loader = new FileGetContentsWebLoader('http://');
         $loader->load('localhost:1234/empty.json');
     }
+    
+    function test_constructor_accepts_decoder_interface() 
+    {
+        $decoder  = new \League\JsonReference\Decoder\YamlDecoder;
+        $loader   = new FileGetContentsWebLoader('http://', $decoder);
+        $response = $loader->load('localhost:1234/string.yaml');
+
+        $this->assertEquals((object) ['type'=>'string'], $response);
+    }
+    
+    function headers()
+    {
+        return [
+            [
+                [
+                    'HTTP/1.1 200 OK',
+                    'Date: Sat, 12 Apr 2008 17:30:38 GMT',
+                    'Server: Apache/2.2.3 (CentOS)',
+                    'Last-Modified: Tue, 15 Nov 2005 13:24:10 GMT',
+                    'ETag: 280100-1b6-80bfd280',
+                    'Accept-Ranges: bytes',
+                    'Content-Length: 438',
+                    'Connection: close',
+                    'Content-Type: text/html; charset=UTF-8'
+                ],
+                [
+                    0 => 'HTTP/1.1 200 OK',
+                    'response_code' => 200,
+                    'Date' => 'Sat, 12 Apr 2008 17:30:38 GMT',
+                    'Server' => 'Apache/2.2.3 (CentOS)',
+                    'Last-Modified' => 'Tue, 15 Nov 2005 13:24:10 GMT',
+                    'ETag' => '280100-1b6-80bfd280',
+                    'Accept-Ranges' => 'bytes',
+                    'Content-Length' => '438',
+                    'Connection' => 'close',
+                    'Content-Type' => 'text/html; charset=UTF-8'
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider headers
+     */
+    function test_it_parses_headers($header, $expectedResult)
+    {
+        $this->assertEquals($expectedResult, FileGetContentsWebLoader::parseHttpResponseHeader($header));
+    }
 }

--- a/tests/Loader/FileLoaderTest.php
+++ b/tests/Loader/FileLoaderTest.php
@@ -4,6 +4,7 @@ namespace League\JsonReference\Test\Loader;
 
 use League\JsonReference\Loader\FileLoader;
 use League\JsonReference\SchemaLoadingException;
+use function peterpostmann\uri\fileuri;
 
 class FileLoaderTest extends \PHPUnit_Framework_TestCase
 {
@@ -12,5 +13,15 @@ class FileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(SchemaLoadingException::class);
         $loader = new FileLoader();
         $response = $loader->load(__DIR__ . '/not-found.json');
+    }
+    
+    function test_constructor_accepts_decoder_interface() 
+    {
+        $decoder  = new \League\JsonReference\Decoder\YamlDecoder;
+        $loader   = new FileLoader($decoder);
+        $path     = substr(fileuri('../fixtures/remotes/string.yaml', __DIR__), 7);
+        $response = $loader->load($path);
+
+        $this->assertEquals((object) ['type'=>'string'], $response);
     }
 }

--- a/tests/LoaderManagerTest.php
+++ b/tests/LoaderManagerTest.php
@@ -5,6 +5,7 @@ namespace League\JsonReference\Test;
 use League\JsonReference\Loader\ArrayLoader;
 use League\JsonReference\LoaderInterface;
 use League\JsonReference\LoaderManager;
+use League\JsonReference\DecoderManager;
 
 class LoaderManagerTest extends \PHPUnit_Framework_TestCase
 {
@@ -47,5 +48,48 @@ class LoaderManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($manager->hasLoader('http'));
         $this->assertFalse($manager->hasLoader('https'));
         $this->assertTrue($manager->hasLoader('array'));
+    }
+    
+    function test_it_returns_decoder_manager()
+    {
+        $loaderManager  = new LoaderManager();
+        $this->assertInstanceOf(DecoderManager::class, $loaderManager->getDecoderManager());       
+    }
+
+    function test_it_loads_from_suffix_first()
+    {
+        $loaderManager = new LoaderManager();
+        $result        = $loaderManager->getLoader('http')->load('localhost:1234/schema.php?type=application/xml+json&content={"type":"string"}');
+
+        $this->assertEquals((object) ['type' => 'string'], $result);  
+    }
+
+    function test_it_loads_from_type_second()
+    {
+        $loaderManager = new LoaderManager();
+        $result        = $loaderManager->getLoader('http')->load('localhost:1234/schema.php?type=application/json&content={"type":"string"}');
+
+        $this->assertEquals((object) ['type' => 'string'], $result);  
+    }
+    
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    function test_it_loads_from_extension_third_and_fail()
+    {
+        $loaderManager = new LoaderManager();
+        $loaderManager->getDecoderManager()->setDefaultType(null);
+        $result        = $loaderManager->getLoader('http')->load('localhost:1234/schema.php?type=&content={"type":"string"}');
+    }
+
+    function test_it_loads_from_extension_third_and_succeed()
+    {
+        $loaderManager = new LoaderManager();
+        $loaderManager->getDecoderManager()->setDefaultType(null);
+        $jsonDecoder   = $loaderManager->getDecoderManager()->getDecoder('json');
+        $loaderManager->getDecoderManager()->registerDecoder('php', $jsonDecoder);
+        $result        = $loaderManager->getLoader('http')->load('localhost:1234/schema.php?type=&content={"type":"string"}');
+
+        $this->assertEquals((object) ['type' => 'string'], $result);  
     }
 }

--- a/tests/fixtures/remotes/albums.yaml
+++ b/tests/fixtures/remotes/albums.yaml
@@ -1,0 +1,3 @@
+type: array
+items:
+    $ref: album.json

--- a/tests/fixtures/remotes/schema.php
+++ b/tests/fixtures/remotes/schema.php
@@ -1,0 +1,6 @@
+<?php
+
+header('Content-Type: '.$_GET["type"]);
+echo $_GET["content"];
+
+?>

--- a/tests/fixtures/remotes/string.yaml
+++ b/tests/fixtures/remotes/string.yaml
@@ -1,0 +1,1 @@
+type: string


### PR DESCRIPTION
Hi,

this is PR 3/3 as discussed in #12. 

A `DecoderManager` is used to manage different decoders for different media types. The logic which decoder may be used is implemented in the Loaders and based on the output of the new `determineMediaType` function.

`determineMediaType` evaluates first the Content-Type header, then the file extension and defaults to null if no type can be determined. The `DecoderManager` has an option to register a defaultType which is used in case that the type is unknown or can not be determined. If no arguments are provided, the `DecoderManager` registers the Json-Decoder and makes it default for all types. The Yaml decoder is not register per default as discussed.

### Open Points 

#### determineMediaType

Right now the decoder fails if the content type is set, but no decoder is registered for this content type, except for the content type "application/octet-stream". In that case the file extension is used if present. 

I think functions is not the right place for this logic, maybe it would be better to do it in the `DecoderManger` and make it pluggable. I'm not so happy about the huge amount of logic which is already there, because it get too complex, but I dont know a better solution at the moment.

Integrating the logic with the `DecoderManger` opens another option, namely to test if parsing is possible if now type can be determined from the headers or file extension. Then the `DecoderManager` should keep track about the Decoders in such a way, that no decoder is tested twice.

#### parseContentTypeHeader, parseHttpResponseHeader

Those functions may be extracted to their own library?

#### getDecoderManager, setDecoderManager (LoaderManager)

The `LoaderManager` has a `getDecoderManager` method which allows the DecoderManager to be access (e.g. to add a Decoder) easily.

```PHP
$deref  = new Dereferencer();
$decoder = new YamlDecoder($deref->getLoaderManager()->getDecoderManager());
$deref->getLoaderManager()->getDecoderManager()->registerDecoder('yaml', $decoder);
$result = $deref->dereference('http://localhost:1234/albums.yaml');
```
Instead of passing the Decoder directly to the Loader, the DecoderManager is passed. The DecoderManager can not be replaced easily, since it would have to be replaced in all Loaders. This would requiere a new function in each Loader or a Proxy Object. Therefore the LoaderManger does not have a `setDecoderManager`. This feals a bit complex. Maybe there is a better way to manage this?

Looking forward for Feedback!
