### PR TITLE
Show full pointer and value in non-existent value error

### DIFF
--- a/src/Pointer.php
+++ b/src/Pointer.php
@@ -38,7 +38,7 @@ final class Pointer
         $value = $this->traverse($pointer);
 
         if ($value instanceof NonExistentValue) {
-            throw InvalidPointerException::nonexistentValue($value->getValue());
+            throw InvalidPointerException::nonexistentValue($value->getValue(), $value->getPointer());
         }
 
         return $value;
@@ -140,13 +140,13 @@ final class Pointer
      */
     private function traverse($pointer)
     {
-        $pointer = $this->parse($pointer);
+        $parsedPointer = $this->parse($pointer);
         $json    = $this->json;
 
-        foreach ($pointer as $segment) {
+        foreach ($parsedPointer as $segment) {
             if ($json instanceof Reference) {
                 if (!$json->has($segment)) {
-                    return new NonExistentValue($segment);
+                    return new NonExistentValue($segment, $pointer);
                 }
                 $json = $json->get($segment);
             } elseif (is_object($json)) {
@@ -155,16 +155,16 @@ final class Pointer
                     $segment = '_empty_';
                 }
                 if (!property_exists($json, $segment)) {
-                    return new NonExistentValue($segment);
+                    return new NonExistentValue($segment, $pointer);
                 }
                 $json = $json->$segment;
             } elseif (is_array($json)) {
                 if (!array_key_exists($segment, $json)) {
-                    return new NonExistentValue($segment);
+                    return new NonExistentValue($segment, $pointer);
                 }
                 $json = $json[$segment];
             } else {
-                return new NonExistentValue($segment);
+                return new NonExistentValue($segment, $pointer);
             }
         }
 

--- a/src/Pointer/InvalidPointerException.php
+++ b/src/Pointer/InvalidPointerException.php
@@ -16,12 +16,17 @@ final class InvalidPointerException extends \InvalidArgumentException
 
     /**
      * @param string $value
+     * @param string $pointer
      *
      * @return static
      */
-    public static function nonexistentValue($value)
+    public static function nonexistentValue($value, $pointer)
     {
-        return new static(sprintf('The pointer referenced a value that does not exist.  The value was: "%s"', $value));
+        return new static(sprintf(
+            'The pointer "%1$s" referenced a value "%2$s" that does not exist.',
+            $pointer,
+            $value
+        ));
     }
 
     /**

--- a/src/Pointer/NonExistentValue.php
+++ b/src/Pointer/NonExistentValue.php
@@ -11,13 +11,19 @@ final class NonExistentValue
      * @var string
      */
     private $value;
+    /**
+     * @var string
+     */
+    private $pointer;
 
     /**
      * @param string $value The referenced value.
+     * @param string $pointer The full pointer which contains the invalid value.
      */
-    public function __construct($value)
+    public function __construct($value, $pointer)
     {
         $this->value = $value;
+        $this->pointer = $pointer;
     }
 
     /**
@@ -26,5 +32,13 @@ final class NonExistentValue
     public function getValue()
     {
         return $this->value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPointer()
+    {
+        return $this->pointer;
     }
 }


### PR DESCRIPTION
Changed the error message in InvalidPointerException.php to show both the pointer and value.
Modified NonExistentValue.php and Pointer.php correspondingly.